### PR TITLE
Fix Keyword Issue

### DIFF
--- a/app/controllers/jobs.controller.js
+++ b/app/controllers/jobs.controller.js
@@ -3,9 +3,6 @@ const unitGroups = require('../data/noc/2016/noc_2016_unit_groups.json')
 const searchablePrograms = require('../data/viu/searchable_programs.json') // NOTE: Only using searchable programs. Not all programs will return results.
 const { getProgram } = require('../helpers/viu_data.helpers.js')
 
-// STORES
-const { getViuPrograms } = require('../stores')
-
 // HELPERS
 const findJobsByCredentialSearch = require('../lib/findJobsByCredentialSearch.js')
 const { pushIfUnique, ensureArray } = require('../helpers/array.helpers.js')
@@ -32,14 +29,7 @@ exports.jobsByProgram = async function (req, res) {
     return res.status(204).send({ data: [], message: 'No jobs found' })
   }
 
-  const {
-    nid,
-    title,
-    noc_search_keywords,
-    known_noc_groups,
-    credential,
-    field_viu_search_keywords,
-  } = program
+  const { title, noc_search_keywords, known_noc_groups, credential } = program
 
   // Extract NOC searchable keywords (searched using the search() helper function)
   const knownKeywords = noc_search_keywords

--- a/app/lib/findJobsByCredentialSearch.js
+++ b/app/lib/findJobsByCredentialSearch.js
@@ -12,7 +12,7 @@ const allUnitGroups = require('../data/noc/2016/noc_2016_unit_groups.json')
  */
 module.exports = ({ credential, searchKeywords }) => {
   // Validate that we have both a credential and search terms. Return empty if not. Note: this should be caught by middleware prior to getting here.
-  if (!credential || !searchKeywords)
+  if (!credential.length || !searchKeywords.length)
     throw new Error('Missing credential or search keywords')
 
   // Filter out unit groups that require years of experience - we want results that are GRADUATE LEVEL ONLY.
@@ -83,7 +83,7 @@ function keywordCombinator(arr1, arr2) {
   const results = []
   for (const item1 of arr1) {
     for (const item2 of arr2) {
-      pushIfUnique(results, [item1, item2])
+      pushIfUnique(results, [item1.toLowerCase(), item2.toLowerCase()])
     }
   }
   return results


### PR DESCRIPTION
Fixes major issue searching keywords. Previously, search terms were NOT being lower-cased. This meant that unless you were passing in search credentials that were already lowercased previously, you wouldn't return any results. This should correct the issue to the point where ALL "searchable programs" are now returning results.